### PR TITLE
update readme to use shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ## Custom Sanic Core
 
-[![Build Status](https://travis-ci.org/ozknightwalker/SanicCore.svg?branch=master)](https://travis-ci.org/ozknightwalker/SanicCore)
-[![codecov](https://codecov.io/gh/ozknightwalker/SanicCore/branch/master/graph/badge.svg)](https://codecov.io/gh/ozknightwalker/SanicCore)
+[![](https://img.shields.io/travis/ozknightwalker/SanicCore/master.svg?style=for-the-badge)](https://travis-ci.org/ozknightwalker/SanicCore)
+[![](https://img.shields.io/codecov/c/github/ozknightwalker/SanicCore.svg?style=for-the-badge)](https://codecov.io/gh/ozknightwalker/SanicCore)
+[![](https://img.shields.io/github/license/ozknightwalker/SanicCore.svg?style=for-the-badge)](https://github.com/ozknightwalker/SanicCore)
+[![](https://img.shields.io/librariesio/github/ozknightwalker/SanicCore.svg?style=for-the-badge)](https://libraries.io/github/ozknightwalker/SanicCore)
 
 This is a boilerplate for my sanic application
+


### PR DESCRIPTION
Changelog:
- update readme to have use shield.io badges
 - codecov, travis build, libraries.io and github license